### PR TITLE
Allow headers to override typ in jwt_encode_sig

### DIFF
--- a/R/jwt.R
+++ b/R/jwt.R
@@ -89,7 +89,7 @@ jwt_encode_sig <- function(claim = jwt_claim(), key, size = 256, header = NULL) 
   jwt_header <- if(inherits(key, "rsa")){
   if(as.list(key)$size < 2048)
     stop("RSA keysize must be at least 2048 bit")
-    to_json(c(list(
+    to_json(modifyList(list(
       typ = "JWT",
       alg = paste0("RS", size)
     ), header))
@@ -97,7 +97,7 @@ jwt_encode_sig <- function(claim = jwt_claim(), key, size = 256, header = NULL) 
     # See http://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-40#section-3.4
     size <- switch(as.list(key)$data$curve,
       "P-256" = 256, "P-384" = 384, "P-521" = 512, stop("invalid curve"))
-    to_json(c(list(
+    to_json(modifyList(list(
       typ = "JWT",
       alg = paste0("ES", size)
     ), header))

--- a/R/jwt.R
+++ b/R/jwt.R
@@ -19,6 +19,7 @@
 #' @param pubkey path or object with RSA or EC public key, see \link[openssl:read_pubkey]{openssl::read_pubkey}.
 #' @importFrom openssl sha2 signature_create signature_verify read_pubkey read_key
 #' @importFrom jsonlite fromJSON toJSON
+#' @importFrom utils modifyList
 #' @examples # HMAC signing
 #' mysecret <- "This is super secret"
 #' token <- jwt_claim(name = "jeroen", session = 123456)

--- a/R/jwt.R
+++ b/R/jwt.R
@@ -80,7 +80,7 @@ jwt_decode_hmac <- function(jwt, secret){
 
 #' @export
 #' @rdname jwt_encode
-jwt_encode_sig <- function(claim = jwt_claim(), key, size = 256, header = NULL) {
+jwt_encode_sig <- function(claim = jwt_claim(), key, size = 256, header = list()) {
   stopifnot(inherits(claim, "jwt_claim"))
   key <- read_key(key)
   if(!inherits(key, "key"))


### PR DESCRIPTION
Small change to use modifyList instead of c, to allow headers to override hard-coded values.
Closes #15, as discussed there.

